### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,10 @@ Sometimes as a developer you need to send snippets of code, publish an issue on 
 
 ## Requirements
 * iOS 8+
-* Cocoa Pods
+* CocoaPods
 * Installation
 
-This project is using Cocoa Pods, to open it please use **keyboard.xcworkspace** and if you have dependencies problems execute the following command in the terminal
+This project is using CocoaPods, to open it please use **keyboard.xcworkspace** and if you have dependencies problems execute the following command in the terminal
 
 `pod install`
 


### PR DESCRIPTION
This pull request corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
